### PR TITLE
feat: sync workflow on PR merge

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,44 @@
+name: Sync branches after PR merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-branch:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Identify base and compare branches
+        id: vars
+        run: |
+          echo "BASE_BRANCH=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+          echo "COMPARE_BRANCH=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+
+      - name: Checkout base branch
+        run: |
+          git checkout ${{ env.BASE_BRANCH }}
+          git pull origin ${{ env.BASE_BRANCH }}
+
+      - name: Sync compare branch with base branch
+        run: |
+          git checkout ${{ env.COMPARE_BRANCH }}
+          git merge --ff-only ${{ env.BASE_BRANCH }} || echo "Already up-to-date"
+
+      - name: Push updates to compare branch
+        run: |
+          git push origin ${{ env.COMPARE_BRANCH }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the synchronization of branches after a pull request is merged. The workflow will ensure that the compare branch is updated with the latest changes from the base branch upon merging.

New GitHub Actions workflow:

* [`.github/workflows/sync.yml`](diffhunk://#diff-147c24905d3ee9d7fb8197574238fb54e3d0e2c8bf95a360ea21d849314d7bf7R1-R44): Added a new workflow named "Sync branches after PR merge" that triggers on closed pull requests, checks if the pull request was merged into the 'main' branch, and synchronizes the compare branch with the base branch.